### PR TITLE
地図表示機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -62,4 +62,5 @@ gem 'active_hash'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem "aws-sdk-s3", require: false
-
+gem "geocoder"
+  

--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem "aws-sdk-s3", require: false
 gem "geocoder"
-  
+gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
     faker (2.22.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
+    geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -302,6 +303,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  geocoder
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -301,6 +305,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  dotenv-rails
   factory_bot_rails
   faker
   geocoder

--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -235,6 +235,16 @@ a {
 
 /* //FURIMAの特徴 */
 
+
+/* 全ての投稿内容の地図表示 */
+.posts-map{
+  width: 100%;
+  height: 600px;
+  background-color: red;
+}
+
+
+
 /* 商品一覧 */
 
 .item-contents {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts
+    # @posts = @user.posts
+    @posts = Post.order('id DESC')  
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,8 @@
 class Post < ApplicationRecord
-
+  # 撮影地の登録時に、geocoderが緯度、経度を自動で登録する設定
+  geocoded_by :shooting_location
+  after_validation :geocode, if: :shooting_location_changed?
+  
   # **バリデーション
   validates :title,               presence: true, length: { maximum: 40 }
   validates :shooting_month_id,   presence: true

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -175,21 +175,21 @@
       transitLayer.setMap(map);
 
 
-      <% @posts.each do |m| %>
+      <% @posts.each do |post| %>
           (function(){
-          var contentString = "タイトル：<%= m.title %>"; // 吹き出しの中身を定義
+          var contentString = "タイトル：<%= post.title %>"; // マーカーにポインターを重ねた時に表示する小さい吹き出しの中身を定義
 
           var marker = new google.maps.Marker({
-              position:{lat: <%= m.latitude %>, lng: <%= m.longitude %>},
+              position:{lat: <%= post.latitude %>, lng: <%= post.longitude %>},
               map: map,
-              title: contentString // 上で定義した吹き出しの中身を呼び出す
+              title: contentString // 上で定義した吹き出しの中身を呼び出す（title →小さなグレーの吹き出し）
           });
-          // var contentString = '撮影地：<%= m.shooting_location %>';
+          var contentString = 'タイトル：<%= post.title %><br>撮影地：<%= post.shooting_location %><br>撮影時期:<%= post.shooting_month.name %><%= post.shooting_week.name %><br><%= link_to '詳細ページ', post_path(post.id) %>';// マーカーにポインターをクリックした時に表示する吹き出しの中身を定義
           var infoWindow = new google.maps.InfoWindow({ // 吹き出しの追加
-            content: contentString // 吹き出しに表示する内容
+            content: contentString // 上で定義した吹き出しの中身を呼び出す（content →大きい白色の吹き出し）
           });
           marker.addListener('click', function() { // マーカーをクリックしたとき
-              infoWindow.open(map, marker); // 吹き出しの表示
+              infoWindow.open(map, marker); // 吹き出しを表示
           });
           })();
       <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -177,21 +177,27 @@
 
       <% @posts.each do |m| %>
           (function(){
-          var contentString = "撮影地：<%= m.title %>"; 
+          var contentString = "タイトル：<%= m.title %>"; // 吹き出しの中身を定義
 
           var marker = new google.maps.Marker({
               position:{lat: <%= m.latitude %>, lng: <%= m.longitude %>},
               map: map,
-              title: contentString
+              title: contentString // 上で定義した吹き出しの中身を呼び出す
           });
-          
+          // var contentString = '撮影地：<%= m.shooting_location %>';
+          var infoWindow = new google.maps.InfoWindow({ // 吹き出しの追加
+            content: contentString // 吹き出しに表示する内容
+          });
+          marker.addListener('click', function() { // マーカーをクリックしたとき
+              infoWindow.open(map, marker); // 吹き出しの表示
+          });
           })();
       <% end %>
       //複数マーカー ここまで  
   }
 </script>
 
-  
+
       <script async defer
         src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
       </script>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -137,7 +137,66 @@
   <%# </div> %>
   <%# /FURIMAの特徴 %>
   <%# 商品一覧 %>
+
+
   <div class='item-contents'>
+
+  <div class='posts-map'>
+      <%# Google map %>
+  <div id='map'></div>
+
+   <style>
+#map {
+  height: 600px;
+  width: 100%;
+}
+</style>
+<script>
+    function initMap() {
+
+      //初期表示位置：東京駅
+      let latlng = new google.maps.LatLng(35.68114292160832, 139.76699220422807);
+      //デザイン
+      let styles = [
+           {
+            stylers: [
+             { "saturation": 0 },
+             { "lightness": 0 }
+            ]
+           }
+          ];
+
+      let map = new google.maps.Map(document.getElementById('map'), {
+          zoom: 8,　　//倍率を決める
+          styles: styles,
+          center: latlng
+      });
+      let transitLayer = new google.maps.TransitLayer();
+      transitLayer.setMap(map);
+
+
+      <% @posts.each do |m| %>
+          (function(){
+          var contentString = "撮影地：<%= m.title %>"; 
+
+          var marker = new google.maps.Marker({
+              position:{lat: <%= m.latitude %>, lng: <%= m.longitude %>},
+              map: map,
+              title: contentString
+          });
+          
+          })();
+      <% end %>
+      //複数マーカー ここまで  
+  }
+</script>
+
+  
+      <script async defer
+        src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
+      </script>
+    </div>
+
     <h2 class='title'>Photograph</h2>
     <div class="subtitle" >
       <%# 新規投稿商品 %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,8 +9,50 @@
         </div>
         <%= image_tag @post.image, class: 'image_size' %>
       </div>
-      <div class="shooting-location-map">
-      Googleマップ
+        <div class="shooting-location-map">
+
+        <script type="text/javascript">
+          function initMap() {
+            // latitude,longitudeから位置を特定
+            var test ={lat: <%= @post.latitude %>, lng: <%= @post.longitude %>};
+            var map = new google.maps.Map(document.getElementById('map'), {
+                      zoom: 15, 
+                      center: test    
+                      });
+            var transitLayer = new google.maps.TransitLayer();
+            transitLayer.setMap(map);
+
+            var contentString = '撮影地：<%= @post.shooting_location %>';
+            var infowindow = new google.maps.InfoWindow({
+              content: contentString
+            });
+
+            //  Map上の指定した位置にピンを挿して表示する
+            var marker = new google.maps.Marker({
+                          position:test,
+                          map: map,
+                          title: contentString
+                        });
+
+            marker.addListener('click', function() {
+              infowindow.open(map, marker);
+            });
+          }
+        </script> 
+
+        <%# 以下の記述の中にあるYOUR_API_KEYには取得したご自身のAPIキーを記述してください %>
+        <script async defer
+                      src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
+        </script>
+        <%# 表示するmapのcssです。ご自身でカスタマイズしてください。高さが設定されていないと表示されないことがあります。 %>
+        <style type="text/css">
+          #map { height: 100%;
+                 width: 100%;}
+        </style>
+
+       <%# mapの表示 %>
+        <div id="map"></div>
+
       </div>
     </div>
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+   timeout: 5,                 # geocoding service timeout (secs)
+   lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+   use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+   api_key: ENV['GOOGLE_MAP_API_KEY'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+   units: :km,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20220917031319_add_map_info_to_posts.rb
+++ b/db/migrate/20220917031319_add_map_info_to_posts.rb
@@ -1,0 +1,6 @@
+class AddMapInfoToPosts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :posts, :latitude, :float
+    add_column :posts, :longitude, :float
+  end   
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_14_140832) do
+ActiveRecord::Schema.define(version: 2022_09_17_031319) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 2022_09_14_140832) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
# WHAT
・postsテーブルに緯度・経度カラム追加（マイグレーションスクリプト作成）
・geocoder導入
・撮影地登録時にgeocoderが緯度/経度を自動で登録する設定
・gem "dotenv-rails"導入
・envファイルのプッシュ対象外の設定
・投稿詳細ページにおける地図表示
・Googleのgeocoder使用設定
・トップページにおける地図表示と各投稿のマーカー表示
・トップページの地図のマーカーをクリック時に吹き出しを表示
・吹き出し内のデータ追加（タイトル、撮影地、撮影時期、詳細ページへのパス）

# WHY
地図表示機能を実装するため